### PR TITLE
move screenshot functionality

### DIFF
--- a/screenshot_organizer.py
+++ b/screenshot_organizer.py
@@ -4,6 +4,7 @@ from watchdog.events import FileSystemEventHandler
 from pathlib import Path
 import os
 import time
+from datetime import datetime
 
 DESKTOP_PATHWAY = "/Users/johnbryce/Desktop"
 
@@ -17,10 +18,6 @@ class ScreenshotHandler(FileSystemEventHandler):
 
         screenshot = event
         move_screenshot(screenshot)
-
-        # This gets called automatically when files are created
-        # Check if it's a screenshot, then do something
-        pass
 
 
 def detect_screenshots():
@@ -38,17 +35,62 @@ def detect_screenshots():
 
 
 def move_screenshot(screenshot):
-    print(f"screenshot detected: {screenshot}")
-    # moves file to organized folder
-    create_folder_structure(screenshot)
+    """
+    Moves a detected screenshot file from the Desktop to an organized daily folder.
+
+    Handles macOS screenshot creation behavior where temporary hidden files (.Screenshot)
+    are created first, then renamed to the final filename (Screenshot).
+
+    Args:
+        screenshot: FileSystemEvent object containing the src_path of the detected screenshot
+    """
+    # create the daily folder structure and get the target directory
+    daily_dir = create_folder_structure()
+    if not daily_dir.exists():
+        print("Daily directory doesn't exist!")
+        return
+
+    try:
+        # wait for macOS to finish the file creation process
+        time.sleep(0.5)
+
+        # Get the initial file path from the watchdog event
+        screenshot_file_path = Path(screenshot.src_path)
+
+        # macOS creates temporary screenshots with .Screenshot prefix, then renames to Screenshot
+        # if the temp file doesn't exist, check for the final renamed file
+        if not screenshot_file_path.exists() and screenshot_file_path.name.startswith(
+            "."
+        ):
+            # remove the leading dot to get the final filename (i.e. remove the . from .Screenshot)
+            final_filename = screenshot_file_path.name[1:]  #
+            screenshot_file_path = screenshot_file_path.parent / final_filename
+
+        # final validation - ensure the file exists before attempting to move
+        if not screenshot_file_path.exists():
+            print(f"Screenshot file not found: {screenshot.src_path}")
+            return
+
+        # construct the destination path and move the file
+        filename = screenshot_file_path.name
+        new_file_path = daily_dir / filename
+        print(f"Moving: {screenshot_file_path} -> {new_file_path}")
+
+        # move the file to the organized folder
+        screenshot_file_path.rename(new_file_path)
+        print(f"Successfully moved screenshot to {new_file_path}")
+
+    except FileNotFoundError:
+        print("Screenshot was not moved to daily directory - file not found")
+    except Exception as e:
+        print(f"Error moving screenshot: {e}")
 
 
-def create_folder_structure(screenshot):
+def create_folder_structure():
     # ensure folder destination exists & create the directories to hold the screenshots
     # 1. initializes the screenshots folder in /Users/username
     home_dir = Path.home()
     screenshots_dir = home_dir / "screenshots"
-
     try:
         screenshots_dir.mkdir()
     except FileExistsError:
@@ -57,6 +99,23 @@ def create_folder_structure(screenshot):
     except PermissionError:
         print("Permission error...")
     # 2. creates the daily folder for the screenshot inside /Users/username/screenshots
+    if screenshots_dir.exists():
+        # create the daily directory formatted as "DD MM YEAR i.e. 17 September 2025"
+        daily_dir = create_daily_directory(screenshots_dir)
+        return daily_dir
+
+
+def create_daily_directory(screenshots_dir):
+    current_date = datetime.now().strftime("%d %B %Y")
+    daily_dir = screenshots_dir / current_date
+    try:
+        daily_dir.mkdir()
+    except FileExistsError:
+        print(f"{daily_dir} directory already exists")
+        pass  # directory already exists
+    except PermissionError:
+        print("Permission error...")
+    return daily_dir
 
 
 # TODO: Rename with clean timestamp format (2025-09-15_14-32-05.png).


### PR DESCRIPTION
- move screen shot functionality created to move a screenshot to the daily_dir (daily directory) folder 
- slight delay and check to ensure temporary ".Screenshot" cases are handled (macOS creates temporary screenshot names by prepended the Screenshot with a '.')